### PR TITLE
add excalidocker-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 
 ### Wiki and Note Taking Apps
 
+- [excalidocker-rs](./excalidocker-rs)
 - [excalidraw](./excalidraw)
 - [hoarder](./hoarder)
 - [kalmia](./kalmia)

--- a/excalidocker-rs/README.md
+++ b/excalidocker-rs/README.md
@@ -1,0 +1,14 @@
+# excalidocker-rs
+
+Convert your docker-compose into excalidraw
+
+## About
+
+An [utility](https://github.com/etolbakov/excalidocker-rs) to convert docker-compose.yaml files into excalidraw files.
+
+
+## Screenshots
+
+excalidocker-rs:
+
+![excalidocker-rs](https://github.com/etolbakov/excalidocker-rs/blob/main/data/img/excalidocker-colour-edge.png)


### PR DESCRIPTION
I decided to raise a PR as `excalidocker-rs` is used for docker-compose files.
@ruanbekker  could you please take a look if it's worth adding?

Regards, Eugene